### PR TITLE
Feature/#23 feed&notice UI

### DIFF
--- a/applications/xquare-user-application/src/App.tsx
+++ b/applications/xquare-user-application/src/App.tsx
@@ -6,6 +6,8 @@ import Layout from "./layout";
 import LoginPage from "./pages/login";
 import SignupPage from "./pages/signup";
 import HomePage from "./pages/home";
+import NoticePage from "./pages/noticepage";
+import FeedPage from "./pages/feedpage";
 
 function App() {
   return (
@@ -20,6 +22,24 @@ function App() {
           element={
             <Layout>
               <HomePage />
+            </Layout>
+          }
+        />
+
+        <Route
+          path="/notice"
+          element={
+            <Layout>
+              <NoticePage />
+            </Layout>
+          }
+        />
+
+        <Route
+          path="/feed"
+          element={
+            <Layout>
+              <FeedPage />
             </Layout>
           }
         />

--- a/applications/xquare-user-application/src/App.tsx
+++ b/applications/xquare-user-application/src/App.tsx
@@ -8,6 +8,7 @@ import SignupPage from "./pages/signup";
 import HomePage from "./pages/home";
 import NoticePage from "./pages/noticepage";
 import FeedPage from "./pages/feedpage";
+import NoticeView from "./pages/noticeview";
 
 function App() {
   return (
@@ -40,6 +41,24 @@ function App() {
           element={
             <Layout>
               <FeedPage />
+            </Layout>
+          }
+        />
+
+        <Route
+          path="/notice/view/:id"
+          element={
+            <Layout>
+              <NoticeView />
+            </Layout>
+          }
+        />
+
+        <Route
+          path="/feed/view/:id"
+          element={
+            <Layout>
+              <NoticeView />
             </Layout>
           }
         />

--- a/applications/xquare-user-application/src/layout.tsx
+++ b/applications/xquare-user-application/src/layout.tsx
@@ -17,12 +17,12 @@ function Layout({
   const navigate = useNavigate();
 
   const navItems = [
-    { id: "home", label: "HOME" },
-    { id: "deployment", label: "DEPLOYMENT" },
-    { id: "network", label: "NETWORK" },
-    { id: "monitor", label: "MONITOR" },
-    { id: "notice", label: "NOTICE" },
-    { id: "feed", label: "FEED" },
+    { id: "home", label: "HOME", path: "/" },
+    { id: "deployment", label: "DEPLOYMENT", path: "/deployment" },
+    { id: "network", label: "NETWORK", path: "/network" },
+    { id: "monitor", label: "MONITOR", path: "/monitor" },
+    { id: "notice", label: "NOTICE", path: "/notice" },
+    { id: "feed", label: "FEED", path: "/feed" },
   ];
 
   const handleNavItemClick = (itemId: string) => {

--- a/applications/xquare-user-application/src/layout.tsx
+++ b/applications/xquare-user-application/src/layout.tsx
@@ -18,19 +18,21 @@ function Layout({
 
   const navItems = [
     { id: "home", label: "HOME" },
-    { id: "notification", label: "NOTIFICATION" },
     { id: "deployment", label: "DEPLOYMENT" },
     { id: "network", label: "NETWORK" },
     { id: "monitor", label: "MONITOR" },
+    { id: "notice", label: "NOTICE" },
+    { id: "feed", label: "FEED" },
   ];
 
   const handleNavItemClick = (itemId: string) => {
     const routeMap: Record<string, string> = {
       home: "/",
-      notification: "/notification",
       deployment: "/deployment",
       network: "/network",
       monitor: "/monitor",
+      notice: "/notice",
+      feed: "/feed",
     };
 
     const path = routeMap[itemId];

--- a/applications/xquare-user-application/src/pages/feedpage.tsx
+++ b/applications/xquare-user-application/src/pages/feedpage.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import { Feed } from "@xquare/user-interfaces";
+
+const FeedPage = () => {
+  return (
+    <Container>
+      <Feed page={3} />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-direction: column;
+  height: 100vh;
+  width: 100%;
+  padding: 10px 40px;
+`;
+
+export default FeedPage;

--- a/applications/xquare-user-application/src/pages/home.tsx
+++ b/applications/xquare-user-application/src/pages/home.tsx
@@ -41,7 +41,7 @@ const HomePage = () => {
   }, [navigate]);
 
   const handleNoticeClick = useCallback(() => {
-    navigate("/notification");
+    navigate("/notice");
   }, [navigate]);
 
   const tabContents = [
@@ -162,8 +162,8 @@ const HomePage = () => {
         </ImgText>
       </HeroSection>
       <NoticeSection>
-        <Summary isHome />
-        <Notice isHome />
+        <Summary page={1} />
+        <Notice page={1} />
       </NoticeSection>
     </Container>
   );

--- a/applications/xquare-user-application/src/pages/noticepage.tsx
+++ b/applications/xquare-user-application/src/pages/noticepage.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import { Notice } from "@xquare/user-interfaces";
+
+const NoticePage = () => {
+  return (
+    <Container>
+      <Notice page={3} />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-direction: column;
+  height: 100vh;
+  width: 100%;
+  padding: 10px 40px;
+`;
+
+export default NoticePage;

--- a/applications/xquare-user-application/src/pages/noticeview.tsx
+++ b/applications/xquare-user-application/src/pages/noticeview.tsx
@@ -1,0 +1,113 @@
+import styled from "@emotion/styled";
+import { Typography, Xquare_colors } from "@xquare/user-interfaces";
+
+const NoticeView = () => {
+  const title = "공지사항 제목";
+  const date = "2024-06-10";
+  const content = `공지사항 내용이 여기에 표시됩니다. 공지사항 내용이 여기에 표시됩니다. 공지사항 내용이 여기에 표시됩니다.`;
+
+  const files = [
+    { name: "공지사항_첨부파일.pdf", url: "/files/공지사항_첨부파일.pdf" },
+    { name: "공지사항_첨부파일2.pdf", url: "/files/공지사항_첨부파일2.pdf" },
+  ];
+
+  return (
+    <Container>
+      <ContentsArea>
+        <Typography size="8x" weight="semiBold">
+          {title}
+        </Typography>
+        <Typography size="4x" weight="regular">
+          {date}
+        </Typography>
+      </ContentsArea>
+
+      <Content>{content}</Content>
+
+      <FileArea>
+        {files.length === 0 ? (
+          <NoFileText>첨부된 파일이 없습니다.</NoFileText>
+        ) : (
+          files.map((file) => (
+            <File key={file.name}>
+              <Typography size="4x" weight="semiBold">
+                첨부파일
+              </Typography>
+              <Typography size="4x" weight="semiBold">
+                |
+              </Typography>
+              <Typography size="4x" weight="regular">
+                <FileLink href={file.url} download={file.name}>
+                  {file.name}
+                </FileLink>
+              </Typography>
+            </File>
+          ))
+        )}
+      </FileArea>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-direction: column;
+  height: 100vh;
+  width: 100%;
+  padding: 20px 40px;
+`;
+
+const ContentsArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid ${Xquare_colors.gray[300]};
+  width: 100%;
+  margin-bottom: 15px;
+`;
+
+const Content = styled.div`
+  font-family: "Pretendard";
+  width: 100%;
+  font-size: 17px;
+  text-align: justify;
+  line-height: 1.5;
+  height: 480px;
+`;
+
+const FileArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 20px 10px;
+  gap: 12px;
+  border-top: 2px solid ${Xquare_colors.gray[300]};
+  border-bottom: 2px solid ${Xquare_colors.gray[300]};
+`;
+
+const File = styled.div`
+  flex-direction: row;
+  display: flex;
+  gap: 10px;
+`;
+
+const NoFileText = styled.div`
+  font-size: 15px;
+  font-weight: 600;
+  color: ${Xquare_colors.gray[500]};
+`;
+
+const FileLink = styled.a`
+  text-decoration: underline;
+  color: ${Xquare_colors.black};
+  font-weight: 500;
+  cursor: pointer;
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export default NoticeView;

--- a/modules/xquare-user-interfaces/src/components/notice/feed.tsx
+++ b/modules/xquare-user-interfaces/src/components/notice/feed.tsx
@@ -83,7 +83,8 @@ function Feed({ page }: feedProps) {
       <div>
         {displayItems.map((item) => (
           <NoticeItem
-            key={item.id}
+            type="feed"
+            id={item.id}
             NoticeValue={item.NoticeValue}
             date={item.date}
           />

--- a/modules/xquare-user-interfaces/src/components/notice/feed.tsx
+++ b/modules/xquare-user-interfaces/src/components/notice/feed.tsx
@@ -5,15 +5,15 @@ import { Subtitle } from "../title/index";
 import { Typography } from "../typography/index";
 import Xquare_colors from "../../styles";
 
-interface NoticeProps {
+interface feedProps {
   page: number;
 }
 
-function Notice({ page }: NoticeProps) {
+function Feed({ page }: feedProps) {
   const navigate = useNavigate();
 
   function handleDeployClick() {
-    navigate("/notice");
+    navigate("/feed");
   }
 
   const items = [
@@ -68,11 +68,11 @@ function Notice({ page }: NoticeProps) {
     page === 1 ? items.slice(0, 4) : page === 2 ? items.slice(0, 7) : items;
 
   return (
-    <Noticecontainer page={page}>
+    <Feedcontainer page={page}>
       <TileArea>
         <Subtitle
-          title={`System Notice`}
-          subTitle={"xquare infrastructure 의 주요 수정사항 및, 공지사항"}
+          title={`XQUARE 소식 피드`}
+          subTitle={"team xquare 의 최신 소식"}
         ></Subtitle>
         {page !== 3 && (
           <ClickableText size="5x" weight="medium" onClick={handleDeployClick}>
@@ -89,11 +89,11 @@ function Notice({ page }: NoticeProps) {
           />
         ))}
       </div>
-    </Noticecontainer>
+    </Feedcontainer>
   );
 }
 
-const Noticecontainer = styled.div<NoticeProps>`
+const Feedcontainer = styled.div<feedProps>`
   display: flex;
   width: ${({ page }) => (page === 1 ? "55%" : page === 2 ? "50%" : "100%")};
   flex-direction: column;
@@ -116,4 +116,4 @@ const ClickableText = styled(Typography)`
   color: ${Xquare_colors.gray[500]};
 `;
 
-export { Notice };
+export { Feed };

--- a/modules/xquare-user-interfaces/src/components/notice/feed.tsx
+++ b/modules/xquare-user-interfaces/src/components/notice/feed.tsx
@@ -5,11 +5,11 @@ import { Subtitle } from "../title/index";
 import { Typography } from "../typography/index";
 import Xquare_colors from "../../styles";
 
-interface feedProps {
+interface FeedProps {
   page: number;
 }
 
-function Feed({ page }: feedProps) {
+function Feed({ page }: FeedProps) {
   const navigate = useNavigate();
 
   function handleDeployClick() {
@@ -94,7 +94,7 @@ function Feed({ page }: feedProps) {
   );
 }
 
-const Feedcontainer = styled.div<feedProps>`
+const Feedcontainer = styled.div<FeedProps>`
   display: flex;
   width: ${({ page }) => (page === 1 ? "55%" : page === 2 ? "50%" : "100%")};
   flex-direction: column;

--- a/modules/xquare-user-interfaces/src/components/notice/index.ts
+++ b/modules/xquare-user-interfaces/src/components/notice/index.ts
@@ -1,2 +1,3 @@
-export { Notice } from "./notice";
 export { NoticeItem } from "./noticeitem/index";
+export { Notice } from "./notice";
+export { Feed } from "./feed";

--- a/modules/xquare-user-interfaces/src/components/notice/notice.tsx
+++ b/modules/xquare-user-interfaces/src/components/notice/notice.tsx
@@ -83,7 +83,8 @@ function Notice({ page }: NoticeProps) {
       <div>
         {displayItems.map((item) => (
           <NoticeItem
-            key={item.id}
+            type="notice"
+            id={item.id}
             NoticeValue={item.NoticeValue}
             date={item.date}
           />

--- a/modules/xquare-user-interfaces/src/components/notice/notice.tsx
+++ b/modules/xquare-user-interfaces/src/components/notice/notice.tsx
@@ -12,7 +12,7 @@ interface NoticeProps {
 function Notice({ page }: NoticeProps) {
   const navigate = useNavigate();
 
-  function handleDeployClick() {
+  function handleViewAllClick() {
     navigate("/notice");
   }
 
@@ -75,7 +75,7 @@ function Notice({ page }: NoticeProps) {
           subTitle={"xquare infrastructure 의 주요 수정사항 및, 공지사항"}
         ></Subtitle>
         {page !== 3 && (
-          <ClickableText size="5x" weight="medium" onClick={handleDeployClick}>
+          <ClickableText size="5x" weight="medium" onClick={handleViewAllClick}>
             전체보기 →
           </ClickableText>
         )}

--- a/modules/xquare-user-interfaces/src/components/notice/noticeitem/noticeitem.tsx
+++ b/modules/xquare-user-interfaces/src/components/notice/noticeitem/noticeitem.tsx
@@ -1,15 +1,24 @@
 import styled from "@emotion/styled";
+import { useNavigate } from "react-router-dom";
 import { Xquare_colors } from "../../../styles/colors";
 
 interface NoticeItemProps {
+  type: "notice" | "feed";
+  id: string | number;
   NoticeValue: string;
   date: string;
 }
 
-function NoticeItem({ NoticeValue, date }: NoticeItemProps) {
+function NoticeItem({ type, id, NoticeValue, date }: NoticeItemProps) {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/${type}/view/${id}`);
+  };
+
   return (
     <Container>
-      <Item>{NoticeValue}</Item>
+      <Item onClick={handleClick}>{NoticeValue}</Item>
       <Date>{date}</Date>
     </Container>
   );
@@ -28,6 +37,7 @@ const Container = styled.div`
 const Item = styled.div`
   display: flex;
   width: 90%;
+  cursor: pointer;
 
   font-size: 15px;
   font-weight: 500;
@@ -36,6 +46,11 @@ const Item = styled.div`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  &:hover {
+    text-decoration: underline;
+    color: ${Xquare_colors.purple[600]};
+  }
 `;
 
 const Date = styled.div`

--- a/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
+++ b/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
@@ -38,7 +38,9 @@ function Sidebar({
 }: SidebarProps) {
   const location = useLocation();
 
-  const [activeItemId, setActiveItemId] = useState<string>(navItems[0].id);
+  const [activeItemId, setActiveItemId] = useState<string>(
+    navItems[0]?.id ?? "",
+  );
 
   useEffect(() => {
     const current = navItems.find(

--- a/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
+++ b/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
@@ -93,4 +93,4 @@ function Sidebar({
   );
 }
 
-export default Sidebar;
+export { Sidebar };

--- a/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
+++ b/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { SidebarHeader } from "./header/sidebar-header";
 import { SidebarSearch } from "./search/sidebar-search";
 import { SidebarItem } from "./item/sidebar-item";
@@ -15,6 +16,7 @@ interface SidebarNavItem {
   id: string;
   label: string;
   subItems?: SidebarNavItem[];
+  path?: string;
 }
 
 interface SidebarProps {
@@ -26,7 +28,7 @@ interface SidebarProps {
   onSearch?: (value: string) => void;
 }
 
-export function Sidebar({
+function Sidebar({
   navItems,
   userName,
   projectName,
@@ -34,7 +36,21 @@ export function Sidebar({
   onNavItemClick,
   onSearch,
 }: SidebarProps) {
+  const location = useLocation();
+
   const [activeItemId, setActiveItemId] = useState<string>(navItems[0].id);
+
+  useEffect(() => {
+    const current = navItems.find(
+      (i) =>
+        i.path === location.pathname ||
+        i.subItems?.some((s) => s.path === location.pathname),
+    );
+
+    if (current) {
+      queueMicrotask(() => setActiveItemId(current.id));
+    }
+  }, [location.pathname, navItems]);
 
   const isMainItemActive = useCallback(
     (itemId: string) =>
@@ -76,3 +92,5 @@ export function Sidebar({
     </SidebarContainer>
   );
 }
+
+export default Sidebar;

--- a/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
+++ b/modules/xquare-user-interfaces/src/components/sidebar/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback } from "react";
 import { useLocation } from "react-router-dom";
 import { SidebarHeader } from "./header/sidebar-header";
 import { SidebarSearch } from "./search/sidebar-search";
@@ -38,21 +38,17 @@ function Sidebar({
 }: SidebarProps) {
   const location = useLocation();
 
-  const [activeItemId, setActiveItemId] = useState<string>(
-    navItems[0]?.id ?? "",
-  );
+  const isMatch = (basePath?: string) =>
+    basePath != null &&
+    (location.pathname === basePath ||
+      location.pathname.startsWith(`${basePath}/`));
 
-  useEffect(() => {
-    const current = navItems.find(
-      (i) =>
-        i.path === location.pathname ||
-        i.subItems?.some((s) => s.path === location.pathname),
-    );
-
-    if (current) {
-      queueMicrotask(() => setActiveItemId(current.id));
-    }
-  }, [location.pathname, navItems]);
+  const activeItemId =
+    navItems.find(
+      (i) => isMatch(i.path) || i.subItems?.some((s) => isMatch(s.path)),
+    )?.id ??
+    navItems[0]?.id ??
+    "";
 
   const isMainItemActive = useCallback(
     (itemId: string) =>
@@ -65,7 +61,6 @@ function Sidebar({
 
   const handleMainItemClick = useCallback(
     (itemId: string) => {
-      setActiveItemId(itemId);
       onNavItemClick(itemId);
     },
     [onNavItemClick],

--- a/modules/xquare-user-interfaces/src/components/summary/summary.tsx
+++ b/modules/xquare-user-interfaces/src/components/summary/summary.tsx
@@ -3,10 +3,10 @@ import { SummaryItem } from "./summaryitem/index";
 import { Subtitle } from "../title/index";
 
 interface SummaryProps {
-  isHome: boolean;
+  page?: number;
 }
 
-function Summary({ isHome }: SummaryProps) {
+function Summary({ page }: SummaryProps) {
   const items = [
     {
       id: 1,
@@ -55,10 +55,10 @@ function Summary({ isHome }: SummaryProps) {
     },
   ];
 
-  const displayItems = isHome ? items.slice(0, 4) : items;
+  const displayItems = page === 1 ? items.slice(0, 4) : items;
 
   return (
-    <Summarycontainer>
+    <Summarycontainer page={page}>
       <Subtitle title={`Summary`} subTitle={"service status"} />
       <div>
         {displayItems.map((item) => (
@@ -72,9 +72,9 @@ function Summary({ isHome }: SummaryProps) {
   );
 }
 
-const Summarycontainer = styled.div`
+const Summarycontainer = styled.div<SummaryProps>`
   display: flex;
-  width: 45%;
+  width: ${({ page }) => (page === 1 ? "45%" : "100%")};
   flex-direction: column;
   gap: 10px;
 `;


### PR DESCRIPTION
Implements a dedicated page for viewing notices and feed items with attached files and content.
Adds routing for notice and feed views based on their IDs.
Updates the notice and feed item components to navigate to the view page upon click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 피드 섹션 및 페이지 추가 (/feed)
  * 공지사항 목록 및 상세 페이지 추가 (/notice, /notice/view/:id, /feed/view/:id)
  * 목록 항목 클릭으로 해당 상세 보기로 이동 가능

* **개선사항**
  * 사이드바·상단 네비게이션에 "피드"·"공지사항" 메뉴 추가 및 경로 정리
  * 공지사항·요약 컴포넌트가 page 기반으로 다양한 뷰를 지원하도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->