### PR TITLE
Fetches all repository types from Github API

### DIFF
--- a/modules/xquare-utils/src/githubapp/repositories.ts
+++ b/modules/xquare-utils/src/githubapp/repositories.ts
@@ -106,7 +106,7 @@ export async function listOrganizationRepositories(
     const all: GithubRepository[] = [];
 
     while (true) {
-      const url = `https://api.github.com/orgs/${orgName}/repos?per_page=${perPage}&page=${page}`;
+      const url = `https://api.github.com/orgs/${orgName}/repos?per_page=${perPage}&page=${page}&type=all`;
       const res = await fetchWithTimeout(url, {
         method: "GET",
         headers: {


### PR DESCRIPTION
Updates the Github API call to include the 'type=all' parameter when listing repositories, ensuring that all repository types (public, private, forks, etc.) are retrieved. This provides a more comprehensive view of repositories within an organization.

Fixes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* GitHub 저장소 목록 조회 시 모든 저장소 유형이 포함되도록 개선되었습니다. 이제 더 완전한 저장소 데이터를 조회할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->