### PR TITLE
Updates traffic and deploy count display

### DIFF
--- a/applications/xquare-user-application/src/pages/home.tsx
+++ b/applications/xquare-user-application/src/pages/home.tsx
@@ -44,6 +44,10 @@ const HomePage = () => {
 
   const { data: applications } = useTeamApplications(selectedTeamId);
 
+  useEffect(() => {
+    setDeployCount(applications?.length ?? 0);
+  }, [applications]);
+
   const applicationIds = useMemo(() => {
     if (!applications || applications.length === 0) return undefined;
     return applications.map((app) => app.id);
@@ -68,7 +72,6 @@ const HomePage = () => {
         deployCount: 0,
         traffic: 0,
       };
-      setDeployCount(userData.deployCount);
       setTraffic(userData.traffic);
     };
     fetchUser();
@@ -117,7 +120,8 @@ const HomePage = () => {
     <TabContentWrapper key="status">
       <TextGroup>
         <Typography size="5x" weight="semiBold">
-          XQUARE를 통하여 <Highlight>{traffic}</Highlight>일 동안 서비스 되고 있어요.
+          XQUARE를 통하여 <Highlight>{traffic}</Highlight>일 동안 서비스 되고
+          있어요.
         </Typography>
         <Typography size="4x" weight="medium">
           XQUARE 인프라를 통해 안정적인 서비스 운영이 가능합니다.

--- a/modules/xquare-user-interfaces/src/components/deploymentcontents/summary.tsx
+++ b/modules/xquare-user-interfaces/src/components/deploymentcontents/summary.tsx
@@ -39,8 +39,8 @@ function SummaryContents({ appDetail, loading, error }: SummaryContentsProps) {
     ? `${appDetail.configuration.github.owner}/${appDetail.configuration.github.repo}`
     : "N/A";
   const owner = appDetail?.configuration?.github?.owner || "N/A";
-  const lastDeploy = "2025-10-10 15:00";
-  const lastbuild = "2025-10-10 14:45";
+  const lastDeploy = "N/A";
+  const lastbuild = "N/A";
   const team = getSelectedTeam()?.name ?? "";
 
   return (


### PR DESCRIPTION
Updates the homepage to dynamically display the application deployment count based on the fetched applications.

Removes the initial hardcoded value and updates the `lastDeploy` and `lastbuild` variables to display "N/A" when no data is available.

Related to #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배포 카운트가 현재 애플리케이션 수와 자동 동기화되도록 개선
  * 마지막 배포 및 빌드 시간 정보 표시 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->