### PR TITLE
Adds next_js_export option for application type

### DIFF
--- a/applications/xquare-user-application/src/pages/createapplication.tsx
+++ b/applications/xquare-user-application/src/pages/createapplication.tsx
@@ -962,6 +962,7 @@ const CreateApplication = () => {
               <option value="vite">vite</option>
               <option value="vue">vue</option>
               <option value="next_js">next_js</option>
+              <option value="next_js_export">next_js_export</option>
               <option value="go">go</option>
               <option value="rust">rust</option>
               <option value="maven">maven</option>

--- a/modules/xquare-user-interfaces/src/components/deploymentcontents/deployment.tsx
+++ b/modules/xquare-user-interfaces/src/components/deploymentcontents/deployment.tsx
@@ -612,6 +612,7 @@ function DeploymentContents({
             <option value="vite">vite</option>
             <option value="vue">vue</option>
             <option value="next_js">next_js</option>
+            <option value="next_js_export">next_js_export</option>
             <option value="go">go</option>
             <option value="rust">rust</option>
             <option value="maven">maven</option>

--- a/modules/xquare-utils/src/application/create.ts
+++ b/modules/xquare-utils/src/application/create.ts
@@ -110,6 +110,7 @@ export const createApplication = async (
     "vite",
     "vue",
     "next_js",
+    "next_js_export",
     "go",
     "rust",
     "maven",

--- a/modules/xquare-utils/src/application/detail.ts
+++ b/modules/xquare-utils/src/application/detail.ts
@@ -21,6 +21,7 @@ const BUILD_REQUIRED_FIELDS: Record<string, string[]> = {
   vite: ["version", "buildCommand", "outputPath"],
   vue: ["version", "buildCommand", "outputPath"],
   next_js: ["version", "buildCommand", "startCommand"],
+  next_js_export: ["version", "buildCommand", "outputPath"],
   go: ["version", "buildCommand", "outputPath"],
   rust: ["version", "buildCommand", "outputPath"],
   maven: ["version", "buildCommand", "outputPath"],

--- a/modules/xquare-utils/src/buildinput/fields.ts
+++ b/modules/xquare-utils/src/buildinput/fields.ts
@@ -18,6 +18,7 @@ export const REQUIRED_FIELDS: Record<string, BuildField[]> = {
   vite: ["VERSION", "BUILD_COMMAND", "OUTPUT_PATH"],
   vue: ["VERSION", "BUILD_COMMAND", "OUTPUT_PATH"],
   next_js: ["VERSION", "BUILD_COMMAND", "START_COMMAND"],
+  next_js_export: ["VERSION", "BUILD_COMMAND", "OUTPUT_PATH"],
   go: ["VERSION", "BUILD_COMMAND", "OUTPUT_PATH"],
   rust: ["VERSION", "BUILD_COMMAND", "OUTPUT_PATH"],
   maven: ["VERSION", "BUILD_COMMAND", "OUTPUT_PATH"],


### PR DESCRIPTION
Extends the application creation and deployment process by including "next_js_export" as a selectable application type.

This addition ensures that users can choose the appropriate configuration for Next.js applications that utilize static exports, affecting the required fields and build/deployment processes.

Related to #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 빌드 유형 옵션 "next_js_export"이 응용 프로그램 빌드 설정 및 배포 설정에서 사용 가능합니다. 필요한 빌드 구성(버전, 빌드 명령어, 출력 경로)이 설정되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->