### PR TITLE
Preserves whitespace in notice content.

### DIFF
--- a/applications/xquare-user-application/src/pages/noticeview.tsx
+++ b/applications/xquare-user-application/src/pages/noticeview.tsx
@@ -19,7 +19,7 @@ const NoticeView = () => {
     document.title = "XQUARE | Notice Detail";
   }, []);
   const { data, loading, error } = useNoticeDetail(
-    Number.isNaN(noticeId) ? undefined : noticeId
+    Number.isNaN(noticeId) ? undefined : noticeId,
   );
 
   const title = data?.title ?? "공지사항";
@@ -89,6 +89,7 @@ const Content = styled.div`
   line-height: 1.5;
   height: 100%;
   padding: 3px 3px;
+  white-space: pre-wrap;
 `;
 
 const FileArea = styled.div`


### PR DESCRIPTION
Ensures that whitespace, such as line breaks, is preserved in the notice content, improving readability and formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 공지사항 콘텐츠의 줄바꿈과 공백이 올바르게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->