### PR TITLE
Adds an authentication guard to the view size warning page.

### DIFF
--- a/applications/xquare-user-application/src/pages/viewsizewarning.tsx
+++ b/applications/xquare-user-application/src/pages/viewsizewarning.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useLocation } from "react-router-dom";
+import { useAuthGuard } from "@xquare/hooks";
 
 export default function ViewSizeWarning() {
+  useAuthGuard();
+
   const location = useLocation();
   const [viewport, setViewport] = useState(() => ({
     width: typeof window === "undefined" ? 0 : window.innerWidth,


### PR DESCRIPTION
Ensures that the view size warning page is protected by requiring users to be authenticated before accessing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 보안

* **접근 제어**
  * ViewSizeWarning 페이지가 이제 인증된 사용자만 접근할 수 있도록 인증 보호 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->