### PR TITLE
feat: 관리자 to 관리자 삭제 기능

### DIFF
--- a/applications/xquare-user-application/src/pages/team.tsx
+++ b/applications/xquare-user-application/src/pages/team.tsx
@@ -360,6 +360,7 @@ export default function TeamPage() {
                 loading={teamDetailLoading}
                 error={teamDetailError}
                 isCurrentUserAdmin={isCurrentUserTeamAdmin}
+                currentUserId={currentUserId}
                 onDeleteMember={handleDeleteMember}
                 deleting={isDeletingMembers}
               />

--- a/modules/xquare-user-interfaces/src/components/teammembers/TeamMembersDetailList.tsx
+++ b/modules/xquare-user-interfaces/src/components/teammembers/TeamMembersDetailList.tsx
@@ -121,6 +121,7 @@ export function TeamMembersDetailList({
             </MemberInfo>
             {isCurrentUserAdmin &&
               onDeleteMember &&
+              currentUserId !== null &&
               member.userId !== currentUserId && (
                 <TrashIconButton
                   type="button"

--- a/modules/xquare-user-interfaces/src/components/teammembers/TeamMembersDetailList.tsx
+++ b/modules/xquare-user-interfaces/src/components/teammembers/TeamMembersDetailList.tsx
@@ -21,6 +21,7 @@ interface TeamMembersDetailListProps {
   loading: boolean;
   error: unknown;
   isCurrentUserAdmin?: boolean;
+  currentUserId?: number | null;
   onDeleteMember?: (userId: number) => void;
   deleting?: boolean;
 }
@@ -30,6 +31,7 @@ export function TeamMembersDetailList({
   loading,
   error,
   isCurrentUserAdmin = false,
+  currentUserId = null,
   onDeleteMember,
   deleting = false,
 }: TeamMembersDetailListProps) {
@@ -119,7 +121,7 @@ export function TeamMembersDetailList({
             </MemberInfo>
             {isCurrentUserAdmin &&
               onDeleteMember &&
-              member.role !== "admin" && (
+              member.userId !== currentUserId && (
                 <TrashIconButton
                   type="button"
                   aria-label="멤버 제거"


### PR DESCRIPTION
관리자 to 관리자 삭제 기능
본인은 삭제 안됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 팀 멤버 관리에서 현재 로그인한 사용자가 자신을 삭제하지 못하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->